### PR TITLE
Feat/recent txs endpoint

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1020,17 +1020,22 @@ paths:
             maximum: 10000
           description: Pagination parameter
         - in: query
-          name: number
+          name: limit
           schema:
             type: integer
             minimum: 1
-            maximum: 100
-          description: Number of transactions to return (default 10)
+            maximum: 10000
+          description: Optional limit on matching transactions to search for, breaking early when the limit is hit. If not specified, searches the entire dataset.
         - in: query
           name: kind
           schema:
             type: string
-          description: Comma-separated list of transaction kinds to filter by (e.g., "bond,withdraw,claimRewards"). If not specified, all transaction kinds are included.
+          description: Comma-separated list of transaction kinds to filter by (e.g., "bond,withdraw,claimRewards"). If not specified, no transaction kind filtering is applied.
+        - in: query
+          name: token
+          schema:
+            type: string
+          description: Comma-separated list of token addresses to filter by. Can only be used when filtering by transfer kinds only (e.g., "kind=shieldingTransfer,unshieldingTransfer"). If not specified, no token filtering is applied.
       responses:
         "200":
           description: Paginated list of recent inner transactions with block heights.

--- a/swagger.yml
+++ b/swagger.yml
@@ -1008,6 +1008,44 @@ paths:
                       type: number
                     last_processed_block_height:
                       type: number
+  /api/v1/chain/recent-inner:
+    get:
+      summary: Get a paginated list of inner transactions starting with the most recent
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+          description: Pagination parameter
+        - in: query
+          name: number
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Number of transactions to return (default 10)
+        - in: query
+          name: kind
+          schema:
+            type: string
+          description: Comma-separated list of transaction kinds to filter by (e.g., "bond,withdraw,claimRewards"). If not specified, all transaction kinds are included.
+      responses:
+        "200":
+          description: Paginated list of recent inner transactions with block heights.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [results, pagination]
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/InnerTransactionWithHeight"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
   /api/v1/chain/history:
     get:
       summary: Get a paginated list of transaction for a list of addresses
@@ -1528,6 +1566,58 @@ components:
           type: string
         epoch:
           type: string
+    InnerTransactionWithHeight:
+      type: object
+      required: [txId, blockHeight, kind, exitCode]
+      properties:
+        txId:
+          type: string
+          description: The transaction ID
+        blockHeight:
+          type: integer
+          description: The block height where this transaction was included
+        kind:
+          type: string
+          enum:
+            [
+              "transparentTransfer",
+              "shieldedTransfer",
+              "shieldingTransfer",
+              "unshieldingTransfer",
+              "mixedTransfer",
+              "bond",
+              "redelegation",
+              "unbond",
+              "withdraw",
+              "claimRewards",
+              "voteProposal",
+              "initProposal",
+              "changeMetadata",
+              "changeCommission",
+              "revealPk",
+              "ibcMsgTransfer",
+              "ibcTransparentTransfer",
+              "ibcShieldingTransfer",
+              "ibcUnshieldingTransfer",
+              "becomeValidator",
+              "deactivateValidator",
+              "reactivateValidator",
+              "unjailValidator",
+              "initAccount",
+              "changeConsensusKey",
+              "unknown",
+            ]
+          description: The type of transaction
+        data:
+          type: string
+          description: Optional transaction data (hex encoded)
+        memo:
+          type: string
+          description: Optional transaction memo
+        exitCode:
+          type: string
+          enum: [applied, rejected]
+          description: Whether the transaction was applied or rejected
     TransactionHistory:
       type: object
       required: [txId, kind, wrapperId, exitCode]

--- a/webserver/src/app.rs
+++ b/webserver/src/app.rs
@@ -134,6 +134,10 @@ impl ApplicationServer {
                     get(transaction_handlers::get_inner_tx),
                 )
                 .route(
+                    "/chain/recent-inner",
+                    get(transaction_handlers::get_recent_inner),
+                )
+                .route(
                     "/chain/history",
                     get(transaction_handlers::get_transaction_history),
                 )

--- a/webserver/src/dto/transaction.rs
+++ b/webserver/src/dto/transaction.rs
@@ -17,10 +17,12 @@ pub struct TransactionHistoryQueryParams {
 pub struct RecentInnerQueryParams {
     #[validate(range(min = 1, max = 10000))]
     pub page: Option<u64>,
-    #[validate(range(min = 1, max = 100))]
-    pub number: Option<u64>,
+    #[validate(range(min = 1, max = 10000))]
+    pub limit: Option<u64>,
     #[serde(default, deserialize_with = "deserialize_kinds_opt")]
     pub kind: Option<Vec<TransactionKind>>,
+    #[serde(default, deserialize_with = "deserialize_tokens_opt")]
+    pub token: Option<Vec<String>>,
 }
 
 // Parse the comma separated list of tx kinds from the query string into a vec of validated tx kinds
@@ -47,6 +49,33 @@ where
                 .map(|p| TransactionKind::deserialize(StrDeserializer::<D::Error>::new(p)))
                 .collect();
             kinds.map(Some)
+        }
+    }
+}
+
+// Parse the comma separated list of token addresses from the query string into a vec of strings
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum TokenList {
+    List(Vec<String>),
+    Csv(String),
+}
+
+fn deserialize_tokens_opt<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<TokenList>::deserialize(deserializer)?;
+    match opt {
+        None => Ok(None),
+        Some(TokenList::List(v)) => Ok(Some(v)),
+        Some(TokenList::Csv(s)) => {
+            let tokens: Vec<String> = s
+                .split(',')
+                .filter(|p| !p.is_empty())
+                .map(|p| p.trim().to_string())
+                .collect();
+            Ok(Some(tokens))
         }
     }
 }

--- a/webserver/src/dto/transaction.rs
+++ b/webserver/src/dto/transaction.rs
@@ -1,3 +1,4 @@
+use crate::response::transaction::TransactionKind;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -8,4 +9,14 @@ pub struct TransactionHistoryQueryParams {
     pub page: Option<u64>,
     #[validate(length(min = 1, max = 10))]
     pub addresses: Vec<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Validate)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentInnerQueryParams {
+    #[validate(range(min = 1, max = 10000))]
+    pub page: Option<u64>,
+    #[validate(range(min = 1, max = 100))]
+    pub number: Option<u64>,
+    pub kind: Option<Vec<TransactionKind>>,
 }

--- a/webserver/src/dto/transaction.rs
+++ b/webserver/src/dto/transaction.rs
@@ -1,6 +1,7 @@
-use crate::response::transaction::TransactionKind;
 use serde::{Deserialize, Serialize};
+use serde::de::value::StrDeserializer;
 use validator::Validate;
+use crate::response::transaction::TransactionKind;
 
 #[derive(Clone, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "camelCase")]
@@ -18,5 +19,34 @@ pub struct RecentInnerQueryParams {
     pub page: Option<u64>,
     #[validate(range(min = 1, max = 100))]
     pub number: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_kinds_opt")]
     pub kind: Option<Vec<TransactionKind>>,
+}
+
+// Parse the comma separated list of tx kinds from the query string into a vec of validated tx kinds
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum KindList {
+    List(Vec<TransactionKind>),
+    Csv(String),
+}
+
+fn deserialize_kinds_opt<'de, D>(deserializer: D) -> Result<Option<Vec<TransactionKind>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<KindList>::deserialize(deserializer)?;
+    match opt {
+        None => Ok(None),
+        Some(KindList::List(v)) => Ok(Some(v)),
+        Some(KindList::Csv(s)) => {
+            let kinds: Result<Vec<_>, D::Error> = s
+                .split(',')
+                .filter(|p| !p.is_empty())
+                .map(|p| p.trim())
+                .map(|p| TransactionKind::deserialize(StrDeserializer::<D::Error>::new(p)))
+                .collect();
+            kinds.map(Some)
+        }
+    }
 }

--- a/webserver/src/error/transaction.rs
+++ b/webserver/src/error/transaction.rs
@@ -14,6 +14,8 @@ pub enum TransactionError {
     Database(String),
     #[error("Rpc error: {0}")]
     Rpc(String),
+    #[error("Token parameter can only be used with transfer transaction kinds. Valid transfer kinds are: {0}")]
+    InvalidTokenParameter(String),
     #[error("Unknown error: {0}")]
     Unknown(String),
 }
@@ -23,6 +25,7 @@ impl IntoResponse for TransactionError {
         let status_code = match self {
             TransactionError::InvalidTxId => StatusCode::BAD_REQUEST,
             TransactionError::TxIdNotFound(_) => StatusCode::NOT_FOUND,
+            TransactionError::InvalidTokenParameter(_) => StatusCode::BAD_REQUEST,
             TransactionError::Unknown(_)
             | TransactionError::Database(_)
             | TransactionError::Rpc(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/webserver/src/handler/transaction.rs
+++ b/webserver/src/handler/transaction.rs
@@ -4,7 +4,9 @@ use axum::http::HeaderMap;
 use axum_extra::extract::Query;
 use axum_macros::debug_handler;
 
-use crate::dto::transaction::TransactionHistoryQueryParams;
+use crate::dto::transaction::{
+    RecentInnerQueryParams, TransactionHistoryQueryParams,
+};
 use crate::error::api::ApiError;
 use crate::error::transaction::TransactionError;
 use crate::response::transaction::{
@@ -75,6 +77,25 @@ pub async fn get_transaction_history(
     let (transactions, total_pages, total_items) = state
         .transaction_service
         .get_addresses_history(query.addresses, page)
+        .await?;
+
+    let response =
+        PaginatedResponse::new(transactions, page, total_pages, total_items);
+
+    Ok(Json(response))
+}
+
+#[debug_handler]
+pub async fn get_recent_inner(
+    _headers: HeaderMap,
+    Query(query): Query<RecentInnerQueryParams>,
+    State(state): State<CommonState>,
+) -> Result<Json<PaginatedResponse<Vec<InnerTransaction>>>, ApiError> {
+    let page = query.page.unwrap_or(1);
+
+    let (transactions, total_pages, total_items) = state
+        .transaction_service
+        .get_recent_inner(query.number, page, query.kind)
         .await?;
 
     let response =

--- a/webserver/src/handler/transaction.rs
+++ b/webserver/src/handler/transaction.rs
@@ -10,7 +10,7 @@ use crate::dto::transaction::{
 use crate::error::api::ApiError;
 use crate::error::transaction::TransactionError;
 use crate::response::transaction::{
-    InnerTransaction, TransactionHistory, WrapperTransaction,
+    InnerTransaction, InnerTransactionWithHeight, TransactionHistory, WrapperTransaction,
 };
 use crate::response::utils::PaginatedResponse;
 use crate::state::common::CommonState;
@@ -90,7 +90,7 @@ pub async fn get_recent_inner(
     _headers: HeaderMap,
     Query(query): Query<RecentInnerQueryParams>,
     State(state): State<CommonState>,
-) -> Result<Json<PaginatedResponse<Vec<InnerTransaction>>>, ApiError> {
+) -> Result<Json<PaginatedResponse<Vec<InnerTransactionWithHeight>>>, ApiError> {
     let page = query.page.unwrap_or(1);
 
     let (transactions, total_pages, total_items) = state

--- a/webserver/src/handler/transaction.rs
+++ b/webserver/src/handler/transaction.rs
@@ -95,7 +95,7 @@ pub async fn get_recent_inner(
 
     let (transactions, total_pages, total_items) = state
         .transaction_service
-        .get_recent_inner(query.number, page, query.kind)
+        .get_recent_inner(query.limit, page, query.kind, query.token)
         .await?;
 
     let response =

--- a/webserver/src/repository/tranasaction.rs
+++ b/webserver/src/repository/tranasaction.rs
@@ -6,7 +6,7 @@ use orm::schema::{
     inner_transactions, transaction_history, wrapper_transactions,
 };
 use orm::transactions::{
-    InnerTransactionDb, TransactionHistoryDb, WrapperTransactionDb,
+    InnerTransactionDb, TransactionHistoryDb, TransactionKindDb, WrapperTransactionDb,
 };
 
 use super::utils::{Paginate, PaginatedResponseDb};
@@ -45,6 +45,12 @@ pub trait TransactionRepositoryTrait {
         &self,
         block_height: i32,
     ) -> Result<Vec<WrapperTransactionDb>, String>;
+    async fn find_recent_inner_txs(
+        &self,
+        number: Option<u64>,
+        page: i64,
+        kinds: Option<Vec<TransactionKindDb>>,
+    ) -> Result<PaginatedResponseDb<InnerTransactionDb>, String>;
 }
 
 #[async_trait]
@@ -142,6 +148,34 @@ impl TransactionRepositoryTrait for TransactionRepository {
                 )
                 .select(WrapperTransactionDb::as_select())
                 .get_results(conn)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
+    }
+
+    async fn find_recent_inner_txs(
+        &self,
+        number: Option<u64>,
+        page: i64,
+        kinds: Option<Vec<TransactionKindDb>>,
+    ) -> Result<PaginatedResponseDb<InnerTransactionDb>, String> {
+        let conn = self.app_state.get_db_connection().await;
+        let limit = number.unwrap_or(10) as i64;
+
+        conn.interact(move |conn| {
+            let mut query = inner_transactions::table.into_boxed();
+
+            // Filter by transaction kind if specified, otherwise default to return all kinds
+            if let Some(kinds) = kinds {
+                query = query.filter(inner_transactions::dsl::kind.eq_any(kinds));
+            }
+
+            query
+                .order(inner_transactions::dsl::id.desc())
+                .limit(limit)
+                .paginate(page)
+                .load_and_count_pages::<InnerTransactionDb>(conn)
         })
         .await
         .map_err(|e| e.to_string())?

--- a/webserver/src/repository/tranasaction.rs
+++ b/webserver/src/repository/tranasaction.rs
@@ -47,9 +47,10 @@ pub trait TransactionRepositoryTrait {
     ) -> Result<Vec<WrapperTransactionDb>, String>;
     async fn find_recent_inner_txs(
         &self,
-        number: Option<u64>,
+        limit: Option<u64>,
         page: i64,
         kinds: Option<Vec<TransactionKindDb>>,
+        tokens: Option<Vec<String>>,
     ) -> Result<PaginatedResponseDb<(InnerTransactionDb, i32)>, String>;
 }
 
@@ -156,26 +157,75 @@ impl TransactionRepositoryTrait for TransactionRepository {
 
     async fn find_recent_inner_txs(
         &self,
-        number: Option<u64>,
+        limit: Option<u64>,
         page: i64,
         kinds: Option<Vec<TransactionKindDb>>,
+        tokens: Option<Vec<String>>,
     ) -> Result<PaginatedResponseDb<(InnerTransactionDb, i32)>, String> {
         let conn = self.app_state.get_db_connection().await;
-        let limit = number.unwrap_or(10) as i64;
 
         conn.interact(move |conn| {
             let mut query = inner_transactions::table
                 .inner_join(wrapper_transactions::table.on(inner_transactions::dsl::wrapper_id.eq(wrapper_transactions::dsl::id)))
                 .into_boxed();
 
-            // Filter by transaction kind if specified, otherwise default to return all kinds
+            // Filter by transaction kind if specified, otherwise return all kinds
             if let Some(kinds) = kinds {
                 query = query.filter(inner_transactions::dsl::kind.eq_any(kinds));
             }
 
+            // Filter by token if specified
+            if let Some(tokens) = tokens {
+                // For regular transfers: check sources and targets tokens
+                let _regular_transfer_kinds = vec![
+                    TransactionKindDb::TransparentTransfer,
+                    TransactionKindDb::ShieldedTransfer,
+                    TransactionKindDb::ShieldingTransfer,
+                    TransactionKindDb::UnshieldingTransfer,
+                    TransactionKindDb::MixedTransfer,
+                ];
+                
+                // For IBC transfers: check IBC token address
+                let _ibc_transfer_kinds = vec![
+                    TransactionKindDb::IbcTransparentTransfer,
+                    TransactionKindDb::IbcShieldingTransfer,
+                    TransactionKindDb::IbcUnshieldingTransfer,
+                ];
+
+                // Build token filter condition
+                let regular_kinds_str = "'transparent_transfer'::transaction_kind,
+                                          'shielded_transfer'::transaction_kind,
+                                          'shielding_transfer'::transaction_kind,
+                                          'unshielding_transfer'::transaction_kind,
+                                          'mixed_transfer'::transaction_kind";
+                let ibc_kinds_str = "'ibc_transparent_transfer'::transaction_kind,
+                                      'ibc_shielding_transfer'::transaction_kind,
+                                      'ibc_unshielding_transfer'::transaction_kind";
+
+                let tokens_str = tokens.iter()
+                    .map(|t| format!("'{}'", t))
+                    .collect::<Vec<_>>()
+                    .join(",");
+
+                // Wrap the OR group in extra parentheses to preserve AND/OR precedence with other filters
+                let token_filter = diesel::dsl::sql::<diesel::sql_types::Bool>(&format!(
+                    "((kind IN ({regular_kinds}) AND ((data::jsonb->'sources'->0->>'token') = ANY(ARRAY[{tokens}]) OR (data::jsonb->'targets'->0->>'token') = ANY(ARRAY[{tokens}])))
+                      OR (kind IN ({ibc_kinds}) AND (data::jsonb->0->'Ibc'->'address'->>'Account') = ANY(ARRAY[{tokens}])))",
+                    regular_kinds = regular_kinds_str,
+                    ibc_kinds = ibc_kinds_str,
+                    tokens = tokens_str
+                ));
+
+                query = query.filter(token_filter);
+            }
+
+            // Apply limit if specified to break early after reaching the requested number of matches 
+            if let Some(limit) = limit {
+                query = query.limit(limit as i64);
+            }
+
             query
                 .order(wrapper_transactions::dsl::block_height.desc())
-                .limit(limit)
                 .select((inner_transactions::all_columns, wrapper_transactions::dsl::block_height))
                 .paginate(page)
                 .load_and_count_pages::<(InnerTransactionDb, i32)>(conn)

--- a/webserver/src/repository/tranasaction.rs
+++ b/webserver/src/repository/tranasaction.rs
@@ -50,7 +50,7 @@ pub trait TransactionRepositoryTrait {
         number: Option<u64>,
         page: i64,
         kinds: Option<Vec<TransactionKindDb>>,
-    ) -> Result<PaginatedResponseDb<InnerTransactionDb>, String>;
+    ) -> Result<PaginatedResponseDb<(InnerTransactionDb, i32)>, String>;
 }
 
 #[async_trait]
@@ -159,12 +159,14 @@ impl TransactionRepositoryTrait for TransactionRepository {
         number: Option<u64>,
         page: i64,
         kinds: Option<Vec<TransactionKindDb>>,
-    ) -> Result<PaginatedResponseDb<InnerTransactionDb>, String> {
+    ) -> Result<PaginatedResponseDb<(InnerTransactionDb, i32)>, String> {
         let conn = self.app_state.get_db_connection().await;
         let limit = number.unwrap_or(10) as i64;
 
         conn.interact(move |conn| {
-            let mut query = inner_transactions::table.into_boxed();
+            let mut query = inner_transactions::table
+                .inner_join(wrapper_transactions::table.on(inner_transactions::dsl::wrapper_id.eq(wrapper_transactions::dsl::id)))
+                .into_boxed();
 
             // Filter by transaction kind if specified, otherwise default to return all kinds
             if let Some(kinds) = kinds {
@@ -172,10 +174,11 @@ impl TransactionRepositoryTrait for TransactionRepository {
             }
 
             query
-                .order(inner_transactions::dsl::id.desc())
+                .order(wrapper_transactions::dsl::block_height.desc())
                 .limit(limit)
+                .select((inner_transactions::all_columns, wrapper_transactions::dsl::block_height))
                 .paginate(page)
-                .load_and_count_pages::<InnerTransactionDb>(conn)
+                .load_and_count_pages::<(InnerTransactionDb, i32)>(conn)
         })
         .await
         .map_err(|e| e.to_string())?

--- a/webserver/src/response/transaction.rs
+++ b/webserver/src/response/transaction.rs
@@ -139,6 +139,39 @@ impl From<TransactionKindDb> for TransactionKind {
     }
 }
 
+impl From<TransactionKind> for TransactionKindDb {
+    fn from(value: TransactionKind) -> Self {
+        match value {
+            TransactionKind::TransparentTransfer => Self::TransparentTransfer,
+            TransactionKind::ShieldedTransfer => Self::ShieldedTransfer,
+            TransactionKind::ShieldingTransfer => Self::ShieldingTransfer,
+            TransactionKind::UnshieldingTransfer => Self::UnshieldingTransfer,
+            TransactionKind::MixedTransfer => Self::MixedTransfer,
+            TransactionKind::Bond => Self::Bond,
+            TransactionKind::Redelegation => Self::Redelegation,
+            TransactionKind::Unbond => Self::Unbond,
+            TransactionKind::Withdraw => Self::Withdraw,
+            TransactionKind::ClaimRewards => Self::ClaimRewards,
+            TransactionKind::VoteProposal => Self::VoteProposal,
+            TransactionKind::InitProposal => Self::InitProposal,
+            TransactionKind::ChangeMetadata => Self::ChangeMetadata,
+            TransactionKind::ChangeCommission => Self::ChangeCommission,
+            TransactionKind::RevealPk => Self::RevealPk,
+            TransactionKind::IbcMsgTransfer => Self::IbcMsgTransfer,
+            TransactionKind::IbcTransparentTransfer => Self::IbcTransparentTransfer,
+            TransactionKind::IbcShieldingTransfer => Self::IbcShieldingTransfer,
+            TransactionKind::IbcUnshieldingTransfer => Self::IbcUnshieldingTransfer,
+            TransactionKind::BecomeValidator => Self::BecomeValidator,
+            TransactionKind::DeactivateValidator => Self::DeactivateValidator,
+            TransactionKind::ReactivateValidator => Self::ReactivateValidator,
+            TransactionKind::UnjailValidator => Self::UnjailValidator,
+            TransactionKind::InitAccount => Self::InitAccount,
+            TransactionKind::ChangeConsensusKey => Self::ChangeConsensusKey,
+            TransactionKind::Unknown => Self::Unknown,
+        }
+    }
+}
+
 impl From<WrapperTransactionDb> for WrapperTransaction {
     fn from(value: WrapperTransactionDb) -> Self {
         Self {

--- a/webserver/src/response/transaction.rs
+++ b/webserver/src/response/transaction.rs
@@ -70,6 +70,17 @@ pub struct ShortInnerTransaction {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct InnerTransactionWithHeight {
+    pub tx_id: String,
+    pub block_height: u64,
+    pub kind: TransactionKind,
+    pub data: Option<String>,
+    pub memo: Option<String>,
+    pub exit_code: TransactionResult,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InnerTransaction {
     pub tx_id: String,
     pub wrapper_id: String,
@@ -202,6 +213,19 @@ impl From<InnerTransactionDb> for InnerTransaction {
             data: value.data,
             memo: value.memo,
             exit_code: TransactionResult::from(value.exit_code),
+        }
+    }
+}
+
+impl From<(InnerTransactionDb, i32)> for InnerTransactionWithHeight {
+    fn from((inner_tx, block_height): (InnerTransactionDb, i32)) -> Self {
+        Self {
+            tx_id: inner_tx.id,
+            block_height: block_height as u64,
+            kind: TransactionKind::from(inner_tx.kind),
+            data: inner_tx.data,
+            memo: inner_tx.memo,
+            exit_code: TransactionResult::from(inner_tx.exit_code),
         }
     }
 }

--- a/webserver/src/service/transaction.rs
+++ b/webserver/src/service/transaction.rs
@@ -98,17 +98,59 @@ impl TransactionService {
 
     pub async fn get_recent_inner(
         &self,
-        number: Option<u64>,
+        limit: Option<u64>,
         page: u64,
         kinds: Option<Vec<TransactionKind>>,
+        tokens: Option<Vec<String>>,
     ) -> Result<(Vec<InnerTransactionWithHeight>, u64, u64), TransactionError> {
+        // Validate that token parameter is only used with transfer kinds
+        if let Some(tokens) = &tokens {
+            if !tokens.is_empty() {
+                let transfer_kinds = vec![
+                    TransactionKind::TransparentTransfer,
+                    TransactionKind::ShieldedTransfer,
+                    TransactionKind::ShieldingTransfer,
+                    TransactionKind::UnshieldingTransfer,
+                    TransactionKind::MixedTransfer,
+                    TransactionKind::IbcTransparentTransfer,
+                    TransactionKind::IbcShieldingTransfer,
+                    TransactionKind::IbcUnshieldingTransfer,
+                ];
+
+                if let Some(kinds) = &kinds {
+                    let non_transfer_kinds: Vec<_> = kinds
+                        .iter()
+                        .filter(|k| !transfer_kinds.contains(k))
+                        .collect();
+                    
+                    if !non_transfer_kinds.is_empty() {
+                        let valid_transfer_kinds = transfer_kinds
+                            .iter()
+                            .map(|k| format!("{:?}", k))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        
+                        return Err(TransactionError::InvalidTokenParameter(valid_transfer_kinds));
+                    }
+                } else {
+                    // No kind filter means "all kinds" which includes non-transfer kinds -> error
+                    let valid_transfer_kinds = transfer_kinds
+                        .iter()
+                        .map(|k| format!("{:?}", k))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(TransactionError::InvalidTokenParameter(valid_transfer_kinds));
+                }
+            }
+        }
+
         let kinds_db = kinds.map(|kinds| {
             kinds.into_iter().map(TransactionKindDb::from).collect()
         });
 
         let (transactions, total_pages, total_items) = self
             .transaction_repo
-            .find_recent_inner_txs(number, page as i64, kinds_db)
+            .find_recent_inner_txs(limit, page as i64, kinds_db, tokens)
             .await
             .map_err(TransactionError::Database)?;
 

--- a/webserver/src/service/transaction.rs
+++ b/webserver/src/service/transaction.rs
@@ -6,8 +6,9 @@ use crate::repository::tranasaction::{
     TransactionRepository, TransactionRepositoryTrait,
 };
 use crate::response::transaction::{
-    InnerTransaction, TransactionHistory, WrapperTransaction,
+    InnerTransaction, TransactionHistory, TransactionKind, WrapperTransaction,
 };
+use orm::transactions::TransactionKindDb;
 
 #[derive(Clone)]
 pub struct TransactionService {
@@ -90,6 +91,29 @@ impl TransactionService {
             txs.into_iter()
                 .map(|(h, t, bh)| TransactionHistory::from(h, t, bh))
                 .collect(),
+            total_pages as u64,
+            total_items as u64,
+        ))
+    }
+
+    pub async fn get_recent_inner(
+        &self,
+        number: Option<u64>,
+        page: u64,
+        kinds: Option<Vec<TransactionKind>>,
+    ) -> Result<(Vec<InnerTransaction>, u64, u64), TransactionError> {
+        let kinds_db = kinds.map(|kinds| {
+            kinds.into_iter().map(TransactionKindDb::from).collect()
+        });
+
+        let (transactions, total_pages, total_items) = self
+            .transaction_repo
+            .find_recent_inner_txs(number, page as i64, kinds_db)
+            .await
+            .map_err(TransactionError::Database)?;
+
+        Ok((
+            transactions.into_iter().map(InnerTransaction::from).collect(),
             total_pages as u64,
             total_items as u64,
         ))

--- a/webserver/src/service/transaction.rs
+++ b/webserver/src/service/transaction.rs
@@ -6,7 +6,7 @@ use crate::repository::tranasaction::{
     TransactionRepository, TransactionRepositoryTrait,
 };
 use crate::response::transaction::{
-    InnerTransaction, TransactionHistory, TransactionKind, WrapperTransaction,
+    InnerTransaction, InnerTransactionWithHeight, TransactionHistory, TransactionKind, WrapperTransaction,
 };
 use orm::transactions::TransactionKindDb;
 
@@ -101,7 +101,7 @@ impl TransactionService {
         number: Option<u64>,
         page: u64,
         kinds: Option<Vec<TransactionKind>>,
-    ) -> Result<(Vec<InnerTransaction>, u64, u64), TransactionError> {
+    ) -> Result<(Vec<InnerTransactionWithHeight>, u64, u64), TransactionError> {
         let kinds_db = kinds.map(|kinds| {
             kinds.into_iter().map(TransactionKindDb::from).collect()
         });
@@ -113,7 +113,7 @@ impl TransactionService {
             .map_err(TransactionError::Database)?;
 
         Ok((
-            transactions.into_iter().map(InnerTransaction::from).collect(),
+            transactions.into_iter().map(InnerTransactionWithHeight::from).collect(),
             total_pages as u64,
             total_items as u64,
         ))


### PR DESCRIPTION
Adds a new endpoint to the webserver that returns a paginated list of inner transactions, sorted starting with the most recent, with optional filtering by tx kind and/or token (for transfer type txs).

Example use case would be a block explorer 'Recent Transactions' page.

It was created because we wanted to add a page to the namada.world explorer to show recent MASP related transactions. Currently, the only way to get a list of recent transactions is to query the most recent x blocks individually for wrapper txs, and then query those (if any) to get the inner tx details. However, you may have to scan dozens of blocks to find enough txs to fill a single page, so this becomes cumbersome.

This PR is live on https://indexer.knowable.run

Example api response:
https://indexer.knowable.run/api/v1/chain/recent-inner?page=1&kind=claimRewards,transparentTransfer,voteProposal

And example usage with the namada.world explorer:
https://deploy-preview-1--explori.netlify.app/masp-transactions