### PR TITLE
update tokenAddress to token for balance queries

### DIFF
--- a/webserver/src/handler/balance.rs
+++ b/webserver/src/handler/balance.rs
@@ -19,7 +19,7 @@ pub async fn get_address_balance(
     let response = balances
         .into_iter()
         .map(|balance| AddressBalanceResponse {
-            token_address: TokenResponse::from(balance.token),
+            token: TokenResponse::from(balance.token),
             min_denom_amount: balance.amount.to_string(),
         })
         .collect();

--- a/webserver/src/response/balance.rs
+++ b/webserver/src/response/balance.rs
@@ -5,6 +5,6 @@ use super::chain::TokenResponse;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddressBalanceResponse {
-    pub token_address: TokenResponse,
+    pub token: TokenResponse,
     pub min_denom_amount: String,
 }


### PR DESCRIPTION
https://[indexer]/api/v1/account/tnam1qzuq58crq9sv35fa79u7a82fy99plk3gpve30cxs

this query returns this currently:

```
[
  {
    "tokenAddress": {
      "address": "tnam1phavrw42dmxuhzzq3fhwagf663ekmf58lqedrqcv",
      "trace": "transfer/channel-7/uosmo"
    },
    "minDenomAmount": "62988"
  },
  {
    "tokenAddress": {
      "address": "tnam1phks0geerggjk96ezhxclt6r5tdgu3usa5zteyyc",
      "trace": "transfer/channel-0/uosmo"
    },
    "minDenomAmount": "0"
  },
]
```

this PR updates `tokenAddress` to `token` to match the shielded balance queries for ease of use in Namadillo.